### PR TITLE
Fix duplicate excerpt on blog post detail pages

### DIFF
--- a/templates/blog/detail.html
+++ b/templates/blog/detail.html
@@ -52,11 +52,6 @@
         <h1 class="mb-6 text-4xl font-bold leading-tight sm:text-5xl text-text">{{ post.title }}</h1>
       {% endif %}
 
-    {# Excerpt #}
-      <p class="leading-relaxed text-l text-text-muted">{{ post.excerpt }}</p>
-
-      <hr class="mb-8 border-gray-200">
-
     {# Body #}
       <div class="max-w-none leading-relaxed prose prose-gray text-text-muted">
         {{ post.body|markdownify }}


### PR DESCRIPTION
Fixes #13

The blog post detail template was rendering `post.excerpt` explicitly as a lead paragraph before `post.body`, but the body already begins with the same text — causing the first paragraph to appear twice.

Removed the duplicate excerpt block and the `<hr>` separator that followed it. The excerpt field is still used for meta description and Open Graph tags.